### PR TITLE
🤖 Actualitzar estructura about-frankie per utilitzar el sistema global CSS amb Atomic Design

### DIFF
--- a/src/components/AboutFrankie.css
+++ b/src/components/AboutFrankie.css
@@ -1,174 +1,42 @@
-.about-frankie {
-  padding: 4rem 2rem;
-  background: var(--background-primary);
-  color: var(--color-text);
-  position: relative;
-  overflow: hidden;
-}
+/* AboutFrankie - CSS específic que complementa el sistema global */
 
-.about-frankie::before {
-  content: '';
-  position: absolute;
-  top: -50%;
-  right: -10%;
-  width: 40%;
-  height: 200%;
-  background: radial-gradient(circle, rgba(59, 130, 246, 0.05) 0%, transparent 70%);
-  pointer-events: none;
-}
-
-.about-frankie__container {
-  max-width: 1200px;
-  margin: 0 auto;
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 3rem;
-  position: relative;
-  z-index: 1;
-}
-
+/* Layout específic de la secció */
 .about-frankie__content {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
-.about-frankie__title {
-  font-size: 2.5rem;
-  font-weight: 800;
-  color: #1e293b;
-  margin: 0;
-  line-height: 1.2;
-}
-
-.about-frankie__text {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.about-frankie__text p {
-  font-size: 1.125rem;
-  line-height: 1.75;
-  color: #475569;
-  margin: 0;
-}
-
-.about-frankie__quote {
-  font-size: 1.25rem;
-  font-style: italic;
-  color: #3b82f6;
-  font-weight: 600;
-  margin: 1rem 0 0;
-  padding: 1.5rem;
-  background: rgba(59, 130, 246, 0.05);
-  border-left: 4px solid #3b82f6;
-  border-radius: 0.5rem;
-}
-
-.about-frankie__visuals {
   display: grid;
-  grid-template-columns: 1fr;
-  gap: 1.5rem;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-2xl);
+  align-items: center;
 }
 
-.about-frankie__image-wrapper {
-  position: relative;
-  width: 100%;
-  padding-bottom: 66.67%; /* 3:2 aspect ratio */
-  border-radius: 1rem;
-  overflow: hidden;
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.1);
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
+/* Efecte hover específic de la imatge */
+.about-frankie__image:hover {
+  transform: scale(1.05);
 }
 
-.about-frankie__image-wrapper:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 15px 50px rgba(0, 0, 0, 0.15);
+/* Layout de features específic */
+.about-frankie__features {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
 }
 
-.about-frankie__image {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+/* Feature item amb efecte hover específic */
+.about-frankie__feature {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-sm);
 }
 
-.about-frankie h2 {
-  text-align: center;
-  font-size: 2.5rem;
-  margin-bottom: 2rem;
-  color: var(--color-primary);
+.about-frankie__feature:hover {
+  transform: translateX(var(--spacing-sm));
 }
 
-.content {
-  background: var(--color-bg);
-  padding: 2rem;
-  border-radius: 15px;
-  line-height: 1.8;
-  color: var(--color-text-secondary);
-}
-
-.highlight {
-  color: var(--color-hover);
-  font-weight: 600;
-}
-
-/* Tablet */
-@media (min-width: 768px) {
-  .about-frankie {
-    padding: 6rem 2rem;
-  }
-
-  .about-frankie__container {
-    gap: 4rem;
-  }
-
-  .about-frankie__title {
-    font-size: 3rem;
-  }
-
-  .about-frankie__visuals {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 2rem;
-  }
-}
-
-/* Desktop */
-@media (min-width: 1024px) {
-  .about-frankie {
-    padding: 8rem 2rem;
-  }
-
-  .about-frankie__container {
-    grid-template-columns: 1fr 1fr;
-    gap: 5rem;
-    align-items: center;
-  }
-
-  .about-frankie__title {
-    font-size: 3.5rem;
-  }
-
-  .about-frankie__text p {
-    font-size: 1.25rem;
-  }
-
-  .about-frankie__quote {
-    font-size: 1.375rem;
-    padding: 2rem;
-  }
-}
-
-/* Accessibilitat */
-@media (prefers-reduced-motion: reduce) {
-  .about-frankie__image-wrapper {
-    transition: none;
-  }
-
-  .about-frankie__image-wrapper:hover {
-    transform: none;
+/* Responsive específic */
+@media (max-width: 768px) {
+  .about-frankie__content {
+    grid-template-columns: 1fr;
+    gap: var(--spacing-xl);
   }
 }


### PR DESCRIPTION
## Implementació automàtica

**Issue #34: Actualitzar estructura about-frankie per utilitzar el sistema global CSS amb Atomic Design**

## Descripció
Refactoritzar l'estructura HTML/CSS de la secció `about-frankie` per utilitzar el sistema global CSS amb Atomic Design que ja està implementat al projecte.

## Context
El projecte ja té un sistema global CSS basat en Atomic Design. Aquesta tasca consisteix en **adaptar la secció about-frankie** per utilitzar aquestes classes i components globals existents, NO modificar el sist

*PR generada automàticament pel coding agent.*

Closes #34