### PR TITLE
🤖 Reemplaçar colors hardcoded per variables CSS --color-text-primary

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -21,23 +21,23 @@ h1 {
 h2 {
   font-size: 2em;
   font-weight: 500;
-  color: #646cff;
+  color: var(--color-text-primary);
   margin-bottom: 1rem;
 }
 
 .subtitle {
   font-size: 1.2em;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--color-text-primary);
   max-width: 600px;
   margin: 0 auto;
 }
 
 @media (prefers-color-scheme: light) {
   h2 {
-    color: #535bf2;
+    color: var(--color-text-primary);
   }
   
   .subtitle {
-    color: rgba(33, 53, 71, 0.8);
+    color: var(--color-text-primary);
   }
 }

--- a/src/components/AILayer.css
+++ b/src/components/AILayer.css
@@ -1,7 +1,7 @@
 .ai-layer {
   padding: 4rem 2rem;
   background: var(--background-primary);
-  color: var(--color-text);
+  color: var(--color-text-primary);
 }
 
 .ai-layer__container {
@@ -12,7 +12,7 @@
 .ai-layer__title {
   font-size: 2.5rem;
   margin-bottom: 2rem;
-  color: #1a1a1a;
+  color: var(--color-text-primary);
   text-align: center;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   font-weight: 600;

--- a/src/components/FinalCTA.css
+++ b/src/components/FinalCTA.css
@@ -63,7 +63,7 @@
 .final-cta-description {
   font-size: 1.25rem;
   line-height: 1.8;
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--color-text-primary);
   margin-bottom: 1rem;
   max-width: 800px;
   margin-left: auto;


### PR DESCRIPTION
## Implementació automàtica

**Issue #43: Reemplaçar colors hardcoded per variables CSS --color-text-primary**

## Descripció
Reemplaçar totes les declaracions `color: xxx` hardcoded en fitxers CSS/SCSS per `color: var(--color-text-primary)`.

## Tasques específiques
- [ ] Buscar tots els fitxers `.css`, `.scss`, `.module.css` del projecte
- [ ] Identificar totes les línies amb `color: #hexcode`, `color: rgb()`, `color: rgba()`, `color: black`, `color: white`, etc.
- [ ] Reemplaçar per `color: var(--color-text-primary)`
- [

*PR generada automàticament pel coding agent.*

Closes #43