### PR TITLE
🤖 Reemplaçar declaracions de color hardcoded per variables CSS

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -21,23 +21,23 @@ h1 {
 h2 {
   font-size: 2em;
   font-weight: 500;
-  color: #646cff;
+  color: var(--color-text-primary);
   margin-bottom: 1rem;
 }
 
 .subtitle {
   font-size: 1.2em;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--color-text-secondary);
   max-width: 600px;
   margin: 0 auto;
 }
 
 @media (prefers-color-scheme: light) {
   h2 {
-    color: #535bf2;
+    color: var(--color-text-primary);
   }
   
   .subtitle {
-    color: rgba(33, 53, 71, 0.8);
+    color: var(--color-text-secondary);
   }
 }

--- a/src/components/AILayer.css
+++ b/src/components/AILayer.css
@@ -1,7 +1,7 @@
 .ai-layer {
   padding: 4rem 2rem;
   background: var(--background-primary);
-  color: var(--color-text);
+  color: var(--color-text-primary);
 }
 
 .ai-layer__container {
@@ -12,7 +12,7 @@
 .ai-layer__title {
   font-size: 2.5rem;
   margin-bottom: 2rem;
-  color: #1a1a1a;
+  color: var(--color-text-primary);
   text-align: center;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   font-weight: 600;

--- a/src/components/FinalCTA.css
+++ b/src/components/FinalCTA.css
@@ -165,7 +165,7 @@
   .final-cta-title {
     font-size: 2rem;
     margin-bottom: 1rem;
-    color: #1a1a1a;
+    color: var(--color-text-primary);
     text-align: center;
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     font-weight: 600;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -15,6 +15,8 @@
   /* ⚪ Colors de Text */
   --color-text-primary: #E6EDF3;
   --color-text-secondary: #9FB0C3;
+  --color-text-muted: #6E7B8A;
+  --color-text-accent: #00D4FF;
   
   /* 🎯 Colors d'Accent */
   --color-hover: #4DE6FF;

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -12,8 +12,12 @@
   color: var(--color-text-secondary);
 }
 
+.text-muted {
+  color: var(--color-text-muted);
+}
+
 .text-accent {
-  color: var(--color-primary);
+  color: var(--color-text-accent);
 }
 
 .bg-surface {


### PR DESCRIPTION
## Implementació automàtica

**Issue #45: Reemplaçar declaracions de color hardcoded per variables CSS**

## Descripció
Necessitem reemplaçar totes les declaracions `color: xxx` hardcoded en tots els fitxers CSS del projecte per utilitzar la variable CSS `color: var(--color-text-primary)`.

## Objectiu
- Millorar la consistència visual del projecte
- Facilitar el manteniment dels colors
- Preparar el terreny per a temes dinàmics (dark/light mode)
- Centralitzar la gestió de colors en variables CSS

## Tasques
- [ ] Identifi

*PR generada automàticament pel coding agent.*

Closes #45