### PR TITLE
🤖 Bug: Errors de TypeScript en translations.ts - interfícies no utilitzades

### DIFF
--- a/src/content/translations.ts
+++ b/src/content/translations.ts
@@ -1,13 +1,5 @@
 import { Language } from '../context/LanguageContext';
 
-interface Translations {
-  greeting: string;
-  projectTitle: string;
-  projectSubtitle: string;
-}
-
-type TranslationsMap = Record<Language, any>;
-
 export const translations = {
   ca: {
     languageSelector: {


### PR DESCRIPTION
## Implementació automàtica

**Issue #62: Bug: Errors de TypeScript en translations.ts - interfícies no utilitzades**

## Descripció del bug
El build falla amb errors de TypeScript a `src/content/translations.ts` per interfícies declarades però no utilitzades.

## Error complet
```
> roborock-chatgpt@0.0.0 build
> tsc && vite build

src/content/translations.ts:3:11 - error TS6196: 'Translations' is declared but never used.

3 interface Translations {
            ~~~~~~~~~~~~

src/content/translations.ts:9:6 - error TS6196: 

*PR generada automàticament pel coding agent.*

Closes #62